### PR TITLE
feat: modules.nixops4Resource.nixos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# `nixops4-nixos`
+
+This repository provides a [NixOps4] integration for deploying NixOS configurations to existing NixOS hosts.
+
+> [!WARNING]
+> This is pre-release software. Features and functionality are subject to change.
+
+> [!NOTE]
+> This is not representative of the final product, which should include convenience options for defining hosts without manually specifying resource definitions.
+
+<!-- markdown links -->
+[NixOps4]: https://nixops.dev

--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,0 +1,35 @@
+{ inputs, ... }:
+{
+  imports = [
+    inputs.git-hooks-nix.flakeModule
+  ];
+  flake.herculesCI.ciSystems = [ "x86_64-linux" ];
+  perSystem =
+    {
+      config,
+      inputs',
+      pkgs,
+      ...
+    }:
+    {
+      checks = {
+        default = pkgs.callPackage ../test/default/nixosTest.nix {
+          nixops4-flake-in-a-bottle = inputs'.nixops4.packages.flake-in-a-bottle;
+          inherit inputs;
+        };
+      };
+      devShells.default = pkgs.mkShellNoCC {
+        nativeBuildInputs = [
+          pkgs.nixfmt-rfc-style
+          inputs'.nixops4.packages.default
+        ];
+        shellHook = ''
+          ${config.pre-commit.settings.installationScript}
+        '';
+      };
+      packages.nixops4-flake-in-a-bottle = pkgs.callPackage ../test/nixops4-flake-in-a-bottle/stuff.nix {
+        nixops4Flake = inputs.nixops4;
+      };
+      pre-commit.settings.hooks.nixfmt-rfc-style.enable = true;
+    };
+}

--- a/example/deployer.pub
+++ b/example/deployer.pub
@@ -1,0 +1,2 @@
+# Put your SSH public key here, e.g. ~/.ssh/id_rsa.pub
+# Make sure it's the PUBLIC key, and NOT the private key

--- a/example/deployment-for-test.nix
+++ b/example/deployment-for-test.nix
@@ -1,0 +1,17 @@
+/**
+  This module is loaded by the integration test.
+  See `flake-module`, where it's imported into `nixops4Deployments.test`.
+*/
+{
+  # Example of explicit configuration
+  hostPort = 22;
+  hostName = "target";
+
+  imports = [
+    # The test will generate some deep overrides for things like the host public key.
+    ./generated.nix
+  ];
+
+  # Test VMs doesn't have a bootloader by default.
+  resources.nixos.nixos.module.boot.loader.grub.enable = false;
+}

--- a/example/deployment.nix
+++ b/example/deployment.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  inputs,
+  lib,
+  providers,
+  withResourceProviderSystem,
+  resourceProviderSystem,
+  ...
+}:
+let
+  pubKeysFile = ./deployer.pub;
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    hostPort = mkOption {
+      type = types.int;
+      default = 2222;
+    };
+    hostName = mkOption {
+      type = types.str;
+      default = "127.0.0.1";
+    };
+  };
+  config = {
+    providers.local = inputs.nixops4.modules.nixops4Provider.local;
+    resources.hello = {
+      type = providers.local.exec;
+      inputs = {
+        executable = withResourceProviderSystem ({ pkgs, ... }: lib.getExe pkgs.hello);
+        args = [
+          "--greeting"
+          "Hallo wereld"
+        ];
+      };
+    };
+    resources.nixos = {
+      type = providers.local.exec;
+      imports = [
+        inputs.nixops4-nixos.modules.nixops4Resource.nixos
+      ];
+
+      nixpkgs = inputs.nixpkgs;
+      nixos.module =
+        { pkgs, modulesPath, ... }:
+        {
+          imports = [
+            # begin hardware config
+            (modulesPath + "/profiles/qemu-guest.nix")
+            (modulesPath + "/../lib/testing/nixos-test-base.nix")
+            {
+              # See test/default/nixosTest.nix
+              system.switch.enable = true;
+              # Not used; save a large copy operation
+              nix.channel.enable = false;
+              nix.registry = lib.mkForce { };
+            }
+            # end hardware config
+          ];
+
+          nixpkgs.hostPlatform = "x86_64-linux";
+
+          services.openssh.enable = true;
+          services.openssh.settings.PermitRootLogin = "yes";
+          networking.firewall.allowedTCPPorts = [ 22 ];
+
+          users.users.root.openssh.authorizedKeys.keyFiles = [ pubKeysFile ];
+          users.users.root.initialPassword = "asdf";
+          users.users.user.openssh.authorizedKeys.keyFiles = [ pubKeysFile ];
+          users.users.user.initialPassword = "asdf";
+          users.users.user.isNormalUser = true;
+          users.users.user.group = "user";
+          users.groups.user = { };
+
+          # end hardware config
+
+          environment.etc."greeting".text = config.resources.hello.outputs.stdout;
+          environment.systemPackages = [
+            pkgs.hello
+          ];
+        };
+
+      ssh.opts = "-o Port=${toString config.hostPort}";
+      ssh.host = config.hostName;
+      ssh.hostPublicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAiszi43aOWWV7voNgQ1Ifa7LGKwGJfOuiLM1n42h2Y8";
+    };
+  };
+}

--- a/example/flake-module.nix
+++ b/example/flake-module.nix
@@ -1,0 +1,21 @@
+{ inputs, ... }:
+{
+  imports = [ inputs.nixops4.modules.flake.default ];
+  nixops4Deployments.default =
+    { ... }:
+    {
+      imports = [
+        ./deployment.nix
+      ];
+      _module.args.inputs = inputs;
+    };
+  nixops4Deployments.test =
+    { ... }:
+    {
+      imports = [
+        ./deployment.nix
+        ./deployment-for-test.nix
+      ];
+      _module.args.inputs = inputs;
+    };
+}

--- a/example/generated.nix
+++ b/example/generated.nix
@@ -1,0 +1,4 @@
+/**
+  This module is just a placeholder. It is overwritten by the test.
+*/
+{ }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,569 @@
+{
+  "nodes": {
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1727316705,
+        "narHash": "sha256-/mumx8AQ5xFuCJqxCIOFCHTVlxHkMT21idpbgbm/TIE=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5b03654ce046b5167e7b0bccbd8244cb56c16f0e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.19.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1735160684,
+        "narHash": "sha256-n5CwhmqKxifuD4Sq4WuRP/h5LO6f23cGnSAuJemnd/4=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "8ce6284ff58208ed8961681276f82c2f8f978ef4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1737465171,
+        "narHash": "sha256-R10v2hoJRLq8jcL4syVFag7nIGE7m13qO48wRIukWNg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "9364dc02281ce2d37a1f55b6e51f7c0f65a75f17",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "git-hooks-nix_2": {
+      "inputs": {
+        "flake-compat": [
+          "nixops4",
+          "nix"
+        ],
+        "gitignore": [
+          "nixops4",
+          "nix"
+        ],
+        "nixpkgs": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nixops4",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1734279981,
+        "narHash": "sha256-NdaCraHPp8iYMWzdXAt5Nv6sA3MUzlCiGiR586TCwo0=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "aa9f40c906904ebd83da78e7f328cd8aeaeae785",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "mk-naked-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681286841,
+        "narHash": "sha256-3XlJrwlR0nBiREnuogoa5i1b4+w/XPe0z8bbrJASw0g=",
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "rev": "7612f828dd6f22b7fb332cc69440e839d7ffe6bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts_3",
+        "git-hooks-nix": "git-hooks-nix_2",
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ],
+        "nixpkgs-23-11": "nixpkgs-23-11",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1736342444,
+        "narHash": "sha256-u6OD0BH+UxyfrWMMpBfM5cz/TDWU9lxJOujgzqBnN9A=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "5230d3ecc4cd3a3d965902a56b5a21bcc99821c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-cargo-integration": {
+      "inputs": {
+        "crane": "crane",
+        "dream2nix": "dream2nix",
+        "mk-naked-shell": "mk-naked-shell",
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ],
+        "parts": "parts",
+        "rust-overlay": "rust-overlay",
+        "treefmt": "treefmt"
+      },
+      "locked": {
+        "lastModified": 1736316962,
+        "narHash": "sha256-nOWLP6pSblYrCipiBb7/SQpGhNe7AHT8m9f++b8/Ni4=",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "rev": "1ce1f666c955e73f65de74f3a8c3ca2c3e5d741b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "type": "github"
+      }
+    },
+    "nixops4": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nix": "nix",
+        "nix-cargo-integration": "nix-cargo-integration",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-old": "nixpkgs-old"
+      },
+      "locked": {
+        "lastModified": 1738308843,
+        "narHash": "sha256-I/+T3qhlcHDP628UjWqugdFKHEsjIA3blWqnoPxQTQ0=",
+        "owner": "nixops4",
+        "repo": "nixops4",
+        "rev": "7e83532e61aa70bccffea93d82e311e0ce07a4d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixops4",
+        "repo": "nixops4",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23-11": {
+      "locked": {
+        "lastModified": 1717159533,
+        "narHash": "sha256-oamiKNfr2MS6yH64rUn99mIZjc45nGJlj9eGth/3Xuw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1730504152,
+        "narHash": "sha256-lXvH/vOfb4aGYyvFmZK/HlsNsr/0CVWlwYvo2rxJk3s=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/cc2f28000298e1269cea6612cd06ec9979dd5d7f.tar.gz"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
+      }
+    },
+    "nixpkgs-old": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "flake-compat": "flake-compat_3",
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1728546539,
+        "narHash": "sha256-Sws7w0tlnjD+Bjck1nv29NjC5DbL6nH5auL9Ex9Iz2A=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "4ad4c15d07bd899d7346b331f377606631eb0ee4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1702448246,
+        "narHash": "sha256-hFg5s/hoJFv7tDpiGvEvXP0UfFvFEDgTdyHIjDVHu1I=",
+        "owner": "davhau",
+        "repo": "pyproject.nix",
+        "rev": "5a06a2697b228c04dd2f35659b4b659ca74f7aeb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "davhau",
+        "ref": "dream2nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixops4": "nixops4",
+        "nixops4-nixos": [],
+        "nixpkgs": [
+          "nixops4",
+          "nixpkgs"
+        ]
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736303309,
+        "narHash": "sha256-IKrk7RL+Q/2NC6+Ql6dwwCNZI6T6JH2grTdJaVWHF0A=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a0b81d4fa349d9af1765b0f0b4a899c13776f706",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688756706,
+        "narHash": "sha256-xzkkMv3neJJJ89zo3o2ojp7nFeaZc2G0fYwNXNJRFlo=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "cf72723f59e2340d24881fd7bf61cb113b4c407c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "nixpkgs": [
+          "nixops4",
+          "nix-cargo-integration",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736154270,
+        "narHash": "sha256-p2r8xhQZ3TYIEKBoiEhllKWQqWNJNoT9v64Vmg4q8Zw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "13c913f5deb3a5c08bb810efd89dc8cb24dd968b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "NixOS integration for NixOps4";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixops4-nixos.follows = ""; # self
+
+    # Dev dependencies
+    # These need to be in the main flake for now, because we can't easily pre-fetch the private flake-compat dependency in flake-parts.
+    # TODO: We could wait for https://github.com/NixOS/nix/issues/7730 or
+    #       1. put a ?narHash= in flake-parts or vendor flake-compat there
+    #       2. partitions.dev.extraInputsFlake = ./dev;
+    nixpkgs.follows = "nixops4/nixpkgs";
+    nixops4.url = "github:nixops4/nixops4";
+    git-hooks-nix.url = "github:cachix/git-hooks.nix";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    {
+      inherit
+        (flake-parts.lib.mkFlake { inherit inputs; } {
+          imports = [
+            inputs.flake-parts.flakeModules.partitions
+            inputs.flake-parts.flakeModules.modules
+            ./main-module.nix
+          ];
+          systems = [
+            "x86_64-linux"
+            "aarch64-linux"
+            "aarch64-darwin"
+            "x86_64-darwin"
+          ];
+          partitions.dev.module = {
+            imports = [
+              ./dev/flake-module.nix
+              ./example/flake-module.nix
+            ];
+          };
+          partitionedAttrs.devShells = "dev";
+          partitionedAttrs.checks = "dev";
+          partitionedAttrs.nixops4Deployments = "dev";
+          partitionedAttrs.herculesCI = "dev";
+        })
+        modules
+        devShells
+        checks
+        /**
+          Example configurations used in integration tests.
+        */
+        nixops4Deployments
+        /**
+          Continuous integration settings
+        */
+        herculesCI
+        ;
+    };
+}

--- a/main-module.nix
+++ b/main-module.nix
@@ -1,0 +1,21 @@
+{
+  flake-parts-lib,
+  self,
+  withSystem,
+  ...
+}:
+{
+  flake.modules = {
+    nixops4Resource = {
+      nixos = flake-parts-lib.importApply ./modules/nixops4Resource/nixos.nix {
+        inherit self withSystem;
+      };
+    };
+    nixosTest = {
+      static = ./modules/nixosTest/static.nix;
+    };
+    nixos = {
+      apply = ./modules/nixos/apply/nixos-apply.nix;
+    };
+  };
+}

--- a/modules/nixops4Resource/nixos.nix
+++ b/modules/nixops4Resource/nixos.nix
@@ -1,0 +1,75 @@
+thisFlake@{ self, withSystem }:
+
+{
+  config,
+  lib,
+  resourceProviderSystem,
+  ...
+}:
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    nixpkgs = mkOption {
+      type =
+        # Why wasn't my flake type merged :(
+        types.flake or types.raw;
+    };
+    nixos.module = mkOption {
+      type = types.deferredModule;
+    };
+    nixos.configuration = mkOption {
+      type = types.raw;
+      readOnly = true;
+    };
+    nixos.specialArgs = mkOption {
+      type = types.raw;
+      default = { };
+    };
+    ssh.user = mkOption {
+      type = types.str;
+      default = "root";
+    };
+    ssh.host = mkOption {
+      type = types.str;
+    };
+    ssh.hostPublicKey = mkOption {
+      type = types.str;
+    };
+    ssh.opts = mkOption {
+      type = types.str;
+      default = "";
+    };
+  };
+  config = {
+    nixos = {
+      configuration = config.nixpkgs.lib.nixosSystem {
+        modules = [
+          config.nixos.module
+          thisFlake.self.modules.nixos.apply
+        ];
+        specialArgs = config.nixos.specialArgs;
+      };
+    };
+    inputs = {
+      executable = "${thisFlake.withSystem resourceProviderSystem ({ pkgs, ... }: lib.getExe pkgs.bash)}";
+      args = [
+        "-c"
+        ''
+          set -euo pipefail
+          export NIX_SSHOPTS="-o StrictHostKeyChecking=yes -o UserKnownHostsFile=${
+            # FIXME: when misconfigured, and this contains a private key, we leak it to the store
+            builtins.toFile "known_hosts" ''
+              ${config.ssh.host} ${config.ssh.hostPublicKey}
+            ''
+          } "${lib.strings.escapeShellArg "${config.ssh.opts}"}
+          nix copy --to "ssh-ng://$0" "$1" --no-check-sigs --extra-experimental-features nix-command
+          ssh $NIX_SSHOPTS "$0" "$1/bin/apply switch"
+        ''
+        "${config.ssh.user}@${config.ssh.host}"
+        config.nixos.configuration.config.system.build.toplevel
+      ];
+    };
+  };
+}

--- a/modules/nixos/apply/README.md
+++ b/modules/nixos/apply/README.md
@@ -1,0 +1,4 @@
+# modules.nixos.apply
+
+This provides the `$toplevel/bin/apply` script if not already provided by NixOS itself.
+Introduced upstream in https://github.com/NixOS/nixpkgs/pull/344407

--- a/modules/nixos/apply/apply.sh
+++ b/modules/nixos/apply/apply.sh
@@ -1,0 +1,147 @@
+#!@bash@
+# vendored from https://github.com/NixOS/nixpkgs/pull/344407
+
+
+# This is the NixOS apply script, typically located at
+#
+# ${config.system.build.toplevel}/bin/apply
+#
+# This script is responsible for managing the profile link and calling the
+# appropriate scripts for its subcommands, such as switch, boot, and test.
+
+
+set -euo pipefail
+
+toplevel=@toplevel@
+
+subcommand=
+
+installBootloader=
+specialisation=
+profile=/nix/var/nix/profiles/system
+
+log() {
+    echo "$@" >&2
+}
+
+die() {
+    log "NixOS apply error: $*"
+    exit 1
+}
+
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            switch|boot|test|dry-activate)
+                subcommand="$1"
+                ;;
+            --install-bootloader)
+                installBootloader=1
+                ;;
+            --profile)
+                if [[ $# -lt 2 ]]; then
+                    die "missing argument for --profile"
+                fi
+                profile="$2"
+                shift
+                ;;
+            # --rollback is not an `apply` responsibility, and it should be
+            # implemented by the caller of `apply` instead.
+            --specialisation)
+                if [[ $# -lt 2 ]]; then
+                    die "missing argument for --specialisation"
+                fi
+                specialisation="$2"
+                shift
+                ;;
+            *)
+                if [[ -n "$subcommand" ]]; then
+                    die "unexpected argument or flag: $1"
+                else
+                    die "unexpected subcommand or flag: $1"
+                fi
+                ;;
+        esac
+        shift
+    done
+
+    if [ -z "$subcommand" ]; then
+        die "no subcommand specified"
+    fi
+}
+
+main() {
+    local cmd activity
+
+    case "$subcommand" in
+        boot|switch)
+            nix-env -p "$profile" --set "$toplevel"
+            ;;
+    esac
+
+    # Using systemd-run here to protect against PTY failures/network
+    # disconnections during rebuild.
+    # See: https://github.com/NixOS/nixpkgs/issues/39118
+    cmd=(
+        "systemd-run"
+        "-E" "LOCALE_ARCHIVE" # Will be set to new value early in switch-to-configuration script, but interpreter starts out with old value
+        "-E" "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
+        "--collect"
+        "--no-ask-password"
+        "--pipe"
+        "--quiet"
+        "--same-dir"
+        "--service-type=exec"
+        "--unit=nixos-rebuild-switch-to-configuration"
+        "--wait"
+    )
+    # Check if we have a working systemd-run. In chroot environments we may have
+    # a non-working systemd, so we fallback to not using systemd-run.
+    if ! "${cmd[@]}" true; then
+        log "Skipping systemd-run to switch configuration since it is not working in target host."
+        cmd=(
+            "env"
+            "-i"
+            "LOCALE_ARCHIVE=${LOCALE_ARCHIVE:-}"
+            "NIXOS_INSTALL_BOOTLOADER=$installBootloader"
+        )
+    fi
+    if [[ -z "$specialisation" ]]; then
+        cmd+=("$toplevel/bin/switch-to-configuration")
+    else
+        cmd+=("$toplevel/specialisation/$specialisation/bin/switch-to-configuration")
+
+        if ! [[ -f "${cmd[-1]}" ]]; then
+            log "error: specialisation not found: $specialisation"
+            exit 1
+        fi
+    fi
+
+    if ! "${cmd[@]}" "$subcommand"; then
+        case "$subcommand" in
+            switch)
+                activity="switching to the new configuration"
+                ;;
+            boot)
+                activity="switching the boot entry to the new configuration"
+                ;;
+            test)
+                activity="switching to the new configuration (in test mode)"
+                ;;
+            dry-activate)
+                activity="switching to the new configuration (in dry-activate mode)"
+                ;;
+            *)  # Should never happen
+                activity="running $subcommand"
+                ;;
+        esac
+        log "warning: error(s) occurred while $activity"
+        exit 1
+    fi
+}
+
+if ! type test_run_tests &>/dev/null; then
+    # We're not loaded into the test.sh, so we run main.
+    parse_args "$@"
+    main
+fi

--- a/modules/nixos/apply/nixos-apply.nix
+++ b/modules/nixos/apply/nixos-apply.nix
@@ -1,0 +1,23 @@
+# Polyfill for https://github.com/NixOS/nixpkgs/pull/344407
+{
+  lib,
+  options,
+  pkgs,
+  ...
+}:
+let
+  alreadyHasApply = options ? system.apply.enable;
+in
+{
+  config = {
+    system.activatableSystemBuilderCommands = lib.mkIf (!alreadyHasApply) (
+      lib.mkAfter ''
+        mkdir -p $out/bin
+        substitute ${./apply.sh} $out/bin/apply \
+          --subst-var-by bash ${lib.getExe pkgs.bash} \
+          --subst-var-by toplevel ''${!toplevelVar}
+        chmod +x $out/bin/apply
+      ''
+    );
+  };
+}

--- a/modules/nixosTest/common.nix
+++ b/modules/nixosTest/common.nix
@@ -1,0 +1,5 @@
+{
+  nodes.deployer = {
+    nix.settings.extra-experimental-features = "flakes";
+  };
+}

--- a/modules/nixosTest/static.nix
+++ b/modules/nixosTest/static.nix
@@ -1,0 +1,7 @@
+{ ... }:
+
+{
+  imports = [
+    ./common.nix
+  ];
+}

--- a/test/default/nixosTest.nix
+++ b/test/default/nixosTest.nix
@@ -1,0 +1,180 @@
+{
+  testers,
+  inputs,
+  nixops4-flake-in-a-bottle,
+  ...
+}:
+
+testers.runNixOSTest (
+  {
+    lib,
+    config,
+    hostPkgs,
+    ...
+  }:
+  let
+    vmSystem = config.node.pkgs.hostPlatform.system;
+
+    # TODO turn example directory into a flake, and refer to the whole repo only
+    #      as a flake input
+    src = lib.fileset.toSource {
+      fileset = ../..;
+      root = ../..;
+    };
+
+    targetNetworkJSON = hostPkgs.writeText "target-network.json" (
+      builtins.toJSON config.nodes.target.system.build.networkConfig
+    );
+
+  in
+  {
+    name = "nixops4-nixos";
+    imports = [
+      inputs.nixops4-nixos.modules.nixosTest.static
+    ];
+
+    nodes = {
+      deployer =
+        { pkgs, nodes, ... }:
+        {
+          environment.systemPackages = [
+            inputs.nixops4.packages.${vmSystem}.default
+          ];
+          # Memory use is expected to be dominated by the NixOS evaluation, which
+          # happens on the deployer.
+          virtualisation.memorySize = 4096;
+          virtualisation.diskSize = 10 * 1024;
+          virtualisation.cores = 2;
+          nix.settings = {
+            substituters = lib.mkForce [ ];
+            hashed-mirrors = null;
+            connect-timeout = 1;
+          };
+          system.extraDependencies =
+            [
+              "${inputs.flake-parts}"
+              "${inputs.flake-parts.inputs.nixpkgs-lib}"
+              "${inputs.nixops4}"
+              "${inputs.nixops4-nixos}"
+              "${inputs.nixpkgs}"
+              pkgs.stdenv
+              pkgs.stdenvNoCC
+              pkgs.hello
+              # Some derivations will be different compared to target's initial state,
+              # so we'll need to be able to build something similar.
+              # Generally the derivation inputs aren't that different, so we use the
+              # initial state of the target as a base.
+              nodes.target.system.build.toplevel.inputDerivation
+              nodes.target.system.build.etc.inputDerivation
+              nodes.target.system.path.inputDerivation
+              nodes.target.system.build.bootStage1.inputDerivation
+              nodes.target.system.build.bootStage2.inputDerivation
+            ]
+            ++ lib.concatLists (
+              lib.mapAttrsToList (
+                k: v: if v ? source.inputDerivation then [ v.source.inputDerivation ] else [ ]
+              ) nodes.target.environment.etc
+            );
+        };
+      target = {
+        # Test framework disables switching by default. That might be ok by itself,
+        # but we also use this config for getting the dependencies in
+        # `deployer.system.extraDependencies`.
+        system.switch.enable = true;
+        # Not used; save a large copy operation
+        nix.channel.enable = false;
+        nix.registry = lib.mkForce { };
+
+        services.openssh.enable = true;
+      };
+    };
+
+    testScript = ''
+      start_all()
+      target.wait_for_unit("multi-user.target")
+      deployer.wait_for_unit("multi-user.target")
+
+      # This mysteriously doesn't work.
+      # target.wait_for_unit("network-online.target")
+      # deployer.wait_for_unit("network-online.target")
+
+      with subtest("unpacking"):
+        deployer.succeed("""
+          cp -r --no-preserve=mode ${src} work
+        """)
+
+      with subtest("configure the deployment"):
+        deployer.copy_from_host("${targetNetworkJSON}", "/root/target-network.json")
+        deployer.succeed("""
+          (
+            cd work
+            set -x
+            mkdir -p ~/.ssh
+            ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+            mv /root/target-network.json example/target-network.json
+          )
+        """)
+        deployer_public_key = deployer.succeed("cat ~/.ssh/id_rsa.pub").strip()
+        target.succeed("mkdir -p /root/.ssh && echo '{}' >> /root/.ssh/authorized_keys".format(deployer_public_key))
+        host_public_key = target.succeed("ssh-keyscan target | grep -v '^#' | cut -f 2- -d ' ' | head -n 1")
+        extra_config = f"""
+          {{ lib, ... }}: {{
+            resources.nixos.ssh.hostPublicKey = lib.mkForce "{host_public_key}";
+            resources.nixos.nixos.module = {{
+              imports = [
+                (lib.modules.importJSON ./target-network.json)
+              ];
+            }};
+          }}
+          """
+        deployer.succeed(f"""cat > work/example/generated.nix <<"_EOF_"\n{extra_config}\n_EOF_\n""")
+        deployer.succeed("""
+          cat -n work/example/generated.nix 1>&2;
+          nix-instantiate work/example/generated.nix --eval --parse >/dev/null
+        """)
+
+      # This is slow, but could be optimized in Nix.
+      # TODO: when not slow, do right after unpacking work/
+      with subtest("override the lock"):
+        deployer.succeed("""
+          (
+            cd work
+            set -x
+            nix flake lock --extra-experimental-features 'flakes nix-command' \
+              --offline -v \
+              --override-input flake-parts ${inputs.flake-parts} \
+              --override-input nixops4 ${nixops4-flake-in-a-bottle} \
+              --override-input nixpkgs ${inputs.nixpkgs} \
+              --override-input git-hooks-nix ${inputs.git-hooks-nix} \
+              ;
+          )
+        """)
+
+      with subtest("nixops4 apply"):
+        deployer.succeed("""
+          (
+            cd work
+            set -x
+            # "test" is the name of the deployment
+            nixops4 apply test --show-trace
+          )
+        """)
+
+      with subtest("check the deployment"):
+        target.succeed("""
+          (
+            set -x
+            hello 1>&2
+          )
+        """)
+        target.succeed("""
+          (
+            set -x
+            cat -n /etc/greeting 1>&2
+            echo "Hallo wereld" | diff /etc/greeting - 1>&2
+          )
+        """)
+      # TODO: nixops4 run feature, calling ssh
+    '';
+  }
+)


### PR DESCRIPTION
This code is based on work done in the eval / poc-nixos / eval-sudo-wip branches in the nixops4 repo.

TODO
- [x] implementation
- [x] test
- [ ] docs
- [x] move flake-in-a-bottle to `nixops4` repo
  - use in test there, replacing part of `test/integration-test-nixops4-with-local/check.nix`
  - add some docs
- [x] fix `_module.args.resourceProviderSystem` in `nixops4`
- [ ] make example usable outside the test, with `nix run` VM runner, tutorial